### PR TITLE
Fix: Edit Form Grid Block with Elementor Pro

### DIFF
--- a/givewp-elementor-widgets.php
+++ b/givewp-elementor-widgets.php
@@ -5,7 +5,7 @@
  * Plugin URI: 		https://givewp.com/givewp-elementor-widgets
  * Description: 	All GiveWP shortcodes as Elementor Widgets
  * Version: 		1.1.1
- * Author: 			GiveWP 
+ * Author: 			GiveWP
  * Author URI: 		https://givewp.com
  * License:      	GNU General Public License v2 or later
  * License URI:  	http://www.gnu.org/licenses/gpl-2.0.html
@@ -84,7 +84,7 @@ final class GiveWP_DW_4_Elementor
 		register_activation_hook(GiveWP_DW_4_Elementor_FILE, array($this, 'install'));
 
 		add_action('give_init', array($this, 'init'), 10, 1);
-		
+
 		add_action( 'admin_enqueue_scripts', array($this, 'load_admin_styles') );
 
 	}
@@ -150,7 +150,7 @@ final class GiveWP_DW_4_Elementor
 		 *
 		 * @since  1.0.0
 		 */
-	
+
 		// Number of days you want the notice delayed by.
 		$delayindays = 15;
 
@@ -194,7 +194,7 @@ final class GiveWP_DW_4_Elementor
 		}
 
 		// Add Plugin actions
-		add_action('elementor/widgets/widgets_registered', [$this, 'init_widgets']);
+		add_action('elementor/widgets/register', [$this, 'init_widgets']);
 
 		add_action('elementor/editor/before_enqueue_scripts', array($this, 'editor_enqueue_scripts'));
 
@@ -327,38 +327,38 @@ final class GiveWP_DW_4_Elementor
 		}
 
 		// Register Donation History widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_Donation_History_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_Donation_History_Widget());
 
 		// Register Receipt widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Receipt_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Receipt_Widget());
 
 		// Register Totals widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Totals_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Totals_Widget());
 
 		// Register Register widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Register_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Register_Widget());
 
 		// Register Login widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Login_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Login_Widget());
 
 		// Register Profile Editor widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Profile_Editor_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Profile_Editor_Widget());
 
 		// Register Donor Wall widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Donor_Wall_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Donor_Wall_Widget());
 
 		// Register Give Goal widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Goal_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Goal_Widget());
 
 		// Register Give Goal widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Form_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Form_Widget());
 
 		// Register Give Goal widget
-		\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Form_Grid_Widget());
+		\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Form_Grid_Widget());
 
 		if ( class_exists('Give_Recurring')) {
 			// Register Give Goal widget
-			\Elementor\Plugin::instance()->widgets_manager->register_widget_type(new \DW4Elementor_GiveWP_Subscriptions_Widget());
+			\Elementor\Plugin::instance()->widgets_manager->register(new \DW4Elementor_GiveWP_Subscriptions_Widget());
 		}
 	}
 

--- a/widgets/donation_history.php
+++ b/widgets/donation_history.php
@@ -84,7 +84,7 @@ class DW4Elementor_Donation_History_Widget extends \Elementor\Widget_Base
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls()
+	protected function register_controls()
 	{
 
 		$this->start_controls_section(

--- a/widgets/give_donor_wall.php
+++ b/widgets/give_donor_wall.php
@@ -24,7 +24,7 @@ class DW4Elementor_GiveWP_Donor_Wall_Widget extends \Elementor\Widget_Base {
 	 * @return string Widget name.
 	 */
 	public function get_name() {
-		return 'Give Donor Wall';
+		return 'Give_Donor_Wall';
 	}
 
 	/**

--- a/widgets/give_donor_wall.php
+++ b/widgets/give_donor_wall.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Give Donor Wall Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Donor_Wall_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Donor_Wall_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'give_donor_wall_settings',
@@ -373,7 +373,7 @@ class DW4Elementor_GiveWP_Donor_Wall_Widget extends \Elementor\Widget_Base {
 		$avatar_size = esc_html( $settings['avatar_size'] );
 		$orderby = esc_html( $settings['orderby'] );
 		$order = esc_html( $settings['order'] );
-		
+
 
 		$html = do_shortcode('
 			[give_donor_wall 
@@ -392,7 +392,7 @@ class DW4Elementor_GiveWP_Donor_Wall_Widget extends \Elementor\Widget_Base {
 				loadmore_text="' . $loadmore_text . '" 
 				avatar_size="' . $avatar_size . '" 
 				order="' . $order . '" 
-				orderby="' . $orderby . 
+				orderby="' . $orderby .
 				'"]'
 		);
 

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Give Form Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'give_form_settings',

--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Give Form Grid Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'give_form_grid_settings',
@@ -358,7 +358,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 		$show_excerpt = esc_html( $settings['show_excerpt'] );
 		$show_featured_image = esc_html( $settings['show_featured_image'] );
 		$display_style = esc_html( $settings['display_style'] );
-		
+
 
 		$html = do_shortcode('
 			[give_form_grid 
@@ -374,7 +374,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 				show_excerpt="' . $show_excerpt . '" 
 				show_featured_image="' . $show_featured_image . '" 
 				display_style="' . $display_style . '" 
-				orderby="' . $orderby . 
+				orderby="' . $orderby .
 				'"]'
 		);
 

--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -24,7 +24,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 * @return string Widget name.
 	 */
 	public function get_name() {
-		return 'GiveWP Form Grid';
+		return 'GiveWP_Form_Grid';
 	}
 
 	/**

--- a/widgets/give_goal.php
+++ b/widgets/give_goal.php
@@ -84,7 +84,7 @@ class DW4Elementor_GiveWP_Goal_Widget extends \Elementor\Widget_Base
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls()
+	protected function register_controls()
 	{
 
 		$this->start_controls_section(

--- a/widgets/give_login.php
+++ b/widgets/give_login.php
@@ -84,7 +84,7 @@ class DW4Elementor_GiveWP_Login_Widget extends \Elementor\Widget_Base
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls()
+	protected function register_controls()
 	{
 
 		$this->start_controls_section(

--- a/widgets/give_profile_editor.php
+++ b/widgets/give_profile_editor.php
@@ -84,7 +84,7 @@ class DW4Elementor_GiveWP_Profile_Editor_Widget extends \Elementor\Widget_Base
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls()
+	protected function register_controls()
 	{
 
 		$this->start_controls_section(

--- a/widgets/give_profile_editor.php
+++ b/widgets/give_profile_editor.php
@@ -28,7 +28,7 @@ class DW4Elementor_GiveWP_Profile_Editor_Widget extends \Elementor\Widget_Base
 	 */
 	public function get_name()
 	{
-		return 'Give Profile Editor';
+		return 'Give_Profile_Editor';
 	}
 
 	/**

--- a/widgets/give_receipt.php
+++ b/widgets/give_receipt.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Donation Receipt Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'content_section',
@@ -255,17 +255,17 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 		// Adding PDF Receipt row, and Subscription table
 		$pdfreceipts = ( class_exists( 'Give_PDF_Receipts' ) ) ? "true" : "false";
 		$recurring = ( class_exists( 'Give_Recurring' ) ) ? "true" : "false";
-		
+
 		if ( ! \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
 
 		$html = do_shortcode('
-			[give_receipt ' 
+			[give_receipt '
 				. $error . ' '
 				. $price . ' '
 				. $donor . ' '
 				. $date . ' '
 				. $method . ' '
-				. $id . ' ' 
+				. $id . ' '
 				. $status . ' '
 				. $company . ' '
 				. $notice .
@@ -278,19 +278,19 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 
 		echo '</div>';
 
-		} else { 
+		} else {
 			?>
 			<div id="give-receipt">
 				<div class="give_notices give_errors" id="give_error_fail">
 					<p class="give_notice give_error">
 						<?php echo (!empty($error) ? $error : __('You are missing the donation ID to view this donation receipt.', 'dw4elementor')); ?>
-					</p>		
+					</p>
 				</div>
 				<?php if ( 'yes' == $settings['status_notice'] ) : ?>
 				<div class="give_notices give_errors" id="give_error_success">
 					<p class="give_notice give_success">
 						<?php echo (!empty($success) ? $success : __('Thank you for your donation.', 'dw4elementor')); ?>
-					</p>		
+					</p>
 				</div>
 				<?php endif; ?>
 				<table id="give_donation_receipt" class="give-table">
@@ -303,25 +303,25 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 					</thead>
 
 					<tbody>
-						<?php 
+						<?php
 						if ( 'yes' == $settings['donor'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Donor', 'dw4elementor'); ?></strong></td>
 							<td><?php _e('Test Donor', 'dw4elementor'); ?></td>
 						</tr>
-						<?php endif; 
+						<?php endif;
 						if ( 'yes' == $settings['company'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Company Name', 'dw4elementor') ;?></strong></td>
 							<td>Impress.org</td>
 						</tr>
-						<?php endif; 
+						<?php endif;
 						if ( 'yes' == $settings['date'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Date', 'dw4elementor'); ?></strong></td>
 							<td><?php _e('April 18, 2020' , 'dw4elementor') ;?></td>
 						</tr>
-						<?php endif; 
+						<?php endif;
 						if ( 'yes' == $settings['price'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Total Donation' ,'dw4elementor'); ?></strong></td>
@@ -332,25 +332,25 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 							<td scope="row"><strong><?php _e('Donation' , 'dw4elementor'); ?></strong></td>
 							<td><?php _e('First Form', 'dw4elementor'); ?><span class="donation-level-text-wrap"></span></td>
 						</tr>
-						<?php 
+						<?php
 						if ( 'yes' == $settings['status'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Donation Status', 'dw4elementor'); ?></strong></td>
 							<td><?php _e('Complete', 'dw4elementor'); ?></td>
 						</tr>
-						<?php endif; 
+						<?php endif;
 						if ( 'yes' == $settings['payment_id'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Donation ID', 'dw4elementor');?></strong></td>
 							<td>3</td>
 						</tr>
-						<?php endif; 
+						<?php endif;
 						if ( 'yes' == $settings['method'] ) : ?>
 						<tr>
 							<td scope="row"><strong><?php _e('Payment Method' , 'dw4elementor'); ?></strong></td>
 							<td><?php _e('Test Donation', 'dw4elementor'); ?></td>
-						</tr>	
-						<?php endif; 
+						</tr>
+						<?php endif;
 						if ( 'true' == $pdfreceipts ) : ?>
 						<tr>
 							<td><strong><?php _e('Receipt', 'dw4elementor'); ?>:</strong></td>
@@ -372,7 +372,7 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 					</thead>
 
 					<tbody>
-					
+
 						<tr>
 							<td scope="row"><strong><?php _e('Subscription:', 'dw4elementor'); ?></strong></td>
 							<td>
@@ -399,7 +399,7 @@ class DW4Elementor_GiveWP_Receipt_Widget extends \Elementor\Widget_Base {
 				</table>
 				<a href="#" class="give-recurring-manage-subscriptions-receipt-link"><?php _e('Manage Subscriptions', 'dw4elementor'); ?> »</a>
 			</div>
-		<?php 
+		<?php
 		 endif; // End if Recurring Donations is active.
 		}
 	}

--- a/widgets/give_register.php
+++ b/widgets/give_register.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Give Register Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Register_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Register_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'give_register_settings',
@@ -146,11 +146,11 @@ class DW4Elementor_GiveWP_Register_Widget extends \Elementor\Widget_Base {
 
 		ob_start(); ?>
 		<form id="give-register-form" class="give-form">
-	
+
 		<fieldset>
 			<legend>Register a New Account</legend>
 
-			
+
 			<div class="form-row form-row-first form-row-responsive">
 				<label for="give-user-login">Username</label>
 				<input id="give-user-login" class="required give-input" type="text" name="give_user_login" required="" aria-required="true">
@@ -171,7 +171,7 @@ class DW4Elementor_GiveWP_Register_Widget extends \Elementor\Widget_Base {
 				<input id="give-user-pass2" class="password required give-input" type="password" name="give_user_pass2" required="" aria-required="true">
 			</div>
 
-			
+
 			<div class="give-hidden">
 				<input type="hidden" name="give_honeypot" value="">
 				<input type="hidden" name="give_action" value="user_register">
@@ -182,11 +182,11 @@ class DW4Elementor_GiveWP_Register_Widget extends \Elementor\Widget_Base {
 				<input class="button" name="give_register_submit" type="submit" value="Register">
 			</div>
 
-			
+
 		</fieldset>
 
 		</form>
-		<?php 
+		<?php
 
 		ob_get_contents();
 

--- a/widgets/give_subscriptions.php
+++ b/widgets/give_subscriptions.php
@@ -84,7 +84,7 @@ class DW4Elementor_GiveWP_Subscriptions_Widget extends \Elementor\Widget_Base
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls()
+	protected function register_controls()
 	{
 
 		$this->start_controls_section(

--- a/widgets/give_totals.php
+++ b/widgets/give_totals.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Elementor Give Totals Widget.
  *
@@ -12,7 +12,7 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 	public function __construct($data = [], $args = null) {
 		parent::__construct($data, $args);
 	}
-	
+
 	/**
 	 * Get widget name.
 	 *
@@ -77,7 +77,7 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 	 * @since 1.0.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->start_controls_section(
 			'give_totals_settings',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #14

## Description

This PR resolves issues where Give Elementor widgets _Give Form Grid_, _Give Donor Wall_, and _Give Profile Editor_ was not possible to edit when Elementor Pro was activated. The problem was in widget configuration, more specifically, each widget that had more than two spaces inside the name definition was not working. For example, if we define widget name as `Give Form Grid`, that won't work when Elementor Pro is activated, but definitions like `Form Grid` will work. The issue is resolved by simply changing the widget's name to a string that doesn't contain spaces.  The name change fix is a breaking change for our users,
meaning that widgets that have name definition updated won't be visible in Elementor editor anymore and users will have to re-insert them. Because of that, only _Give Form Grid_, _Give Donor Wall_, and _Give Profile Editor_ have name definitions updated.

Also, deprecated Elementor API function calls are updated as well.  

## Affects
Give Form Grid, Give Donor Wall, and Give Profile Editor widgets 

## Visuals


![Screen Capture_select-area_20220324154354](https://user-images.githubusercontent.com/4222590/159942045-fd46032a-681b-4bc0-8bb7-64ece1d12834.gif)

## Testing Instructions

You will need Elementor Pro which you can get from here https://drive.google.com/drive/u/0/folders/1S7O7r7GTMA7YS8NG8fBSP-Db7DbZVtCU

1. After you setup Elementor and activated Elementor pro, add a new WP page
2. Insert Give Form Grid widget into the page
3. Click somewhere outside the inserted widget so that is not focused  ( widget controls should be hidden now )
4. Now click on the widget again ( widget controls should be visible now )

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

