### PR TITLE
Give 3.0 compatibility

### DIFF
--- a/assets/dw4elementor-admin.css
+++ b/assets/dw4elementor-admin.css
@@ -55,11 +55,16 @@
     background: #c13f16;
 }
 
+.give-elementor-notice {
+    padding: 10px 0;
+    color: #c13f16;
+}
+
 /*
- * Hide Link Options 
+ * Hide Link Options
  * Until this issue is resolved:
  * https://github.com/elementor/elementor/issues/11214
- * 
+ *
  */
 
 .elementor-control-give_register_settings + .elementor-control-link .elementor-control-url-more,

--- a/givewp-elementor-widgets.php
+++ b/givewp-elementor-widgets.php
@@ -108,7 +108,7 @@ final class GiveWP_DW_4_Elementor
 
 		// Set it to latest.
 		if (!defined('GiveWP_DW_4_Elementor_MIN_GIVE_VERSION')) {
-			define('GiveWP_DW_4_Elementor_MIN_GIVE_VERSION', '2.5');
+			define('GiveWP_DW_4_Elementor_MIN_GIVE_VERSION', '3.0.0');
 		}
 
 		if (!defined('GiveWP_DW_4_Elementor_FILE')) {

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -313,7 +313,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     {
         $data = [];
 
-        foreach ($forms as $formId => $title) {
+        foreach (array_keys($forms) as $formId) {
             if ('legacy' === Give()->form_meta->get_meta($formId, '_give_form_template', true)) {
                 $data[] = (string)$formId;
             }
@@ -331,7 +331,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     {
         $data = [];
 
-        foreach ($forms as $formId => $title) {
+        foreach (array_keys($forms) as $formId) {
             if (Give()->form_meta->get_meta($formId, 'formBuilderSettings', true)) {
                 $data[] = (string)$formId;
             }

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -305,6 +305,10 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     }
 
     /**
+     * Get legacy forms from list of forms returned by DW4Elementor_GiveWP_Form_Widget::get_donation_forms_options
+     *
+     * @unlreased
+     *
      * @param array $forms
      *
      * @return array
@@ -323,6 +327,10 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     }
 
     /**
+     * Get v3 forms from list of forms returned by DW4Elementor_GiveWP_Form_Widget::get_donation_forms_options
+     *
+     * @unlreased
+     *
      * @param array $forms
      *
      * @return array

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -2,6 +2,7 @@
 
 use Give\DonationForms\Models\DonationForm;
 use Give\Framework\Database\DB;
+use Give\Helpers\Form\Utils;
 
 /**
  * Elementor Give Form Widget.
@@ -268,7 +269,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
 
         if (isset($_POST['action']) && $_POST['action'] === 'elementor_ajax') {
             // is this v3 form?
-            if (get_post_meta($form_id, 'formBuilderSettings', true)) {
+            if (Utils::isV3Form($form_id)) {
                 if ($donationForm = DonationForm::find($form_id)) {
                     $donationForm->settings->showHeading        = boolval($show_title);
                     $donationForm->settings->enableDonationGoal = boolval($show_goal);
@@ -372,7 +373,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
         $data = [];
 
         foreach (array_keys($forms) as $formId) {
-            if (get_post_meta($formId, 'formBuilderSettings', true)) {
+            if (Utils::isV3Form($formId)) {
                 $data[] = (string)$formId;
             }
         }

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -1,4 +1,8 @@
 <?php
+
+use Give\DonationForms\Models\DonationForm;
+use Give\Framework\Database\DB;
+
 /**
  * Elementor Give Form Widget.
  *
@@ -6,254 +10,262 @@
  *
  * @since 1.0.0
  */
+class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
+{
 
-class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base {
+    public function __construct($data = [], $args = null)
+    {
+        parent::__construct($data, $args);
+    }
 
-	public function __construct($data = [], $args = null) {
-		parent::__construct($data, $args);
-	}
+    /**
+     * Get widget name.
+     *
+     * Retrieve Give Form widget name.
+     *
+     * @since  1.0.0
+     * @access public
+     *
+     * @return string Widget name.
+     */
+    public function get_name()
+    {
+        return 'Give Form';
+    }
 
-	/**
-	 * Get widget name.
-	 *
-	 * Retrieve Give Form widget name.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string Widget name.
-	 */
-	public function get_name() {
-		return 'Give Form';
-	}
+    /**
+     * Get widget title.
+     *
+     * Retrieve Give Form widget title.
+     *
+     * @since  1.0.0
+     * @access public
+     *
+     * @return string Widget title.
+     */
+    public function get_title()
+    {
+        return __('Give Form', 'dw4elementor');
+    }
 
-	/**
-	 * Get widget title.
-	 *
-	 * Retrieve Give Form widget title.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string Widget title.
-	 */
-	public function get_title() {
-		return __( 'Give Form', 'dw4elementor' );
-	}
+    /**
+     * Get widget icon.
+     *
+     * Retrieve Give Form widget icon.
+     *
+     * @since  1.0.0
+     * @access public
+     *
+     * @return string Widget icon.
+     */
+    public function get_icon()
+    {
+        return 'dw4elementor-icon';
+    }
 
-	/**
-	 * Get widget icon.
-	 *
-	 * Retrieve Give Form widget icon.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string Widget icon.
-	 */
-	public function get_icon() {
-		return 'dw4elementor-icon';
-	}
+    /**
+     * Get widget categories.
+     *
+     * Retrieve the list of categories the Give Form widget belongs to.
+     *
+     * @since  1.0.0
+     * @access public
+     *
+     * @return array Widget categories.
+     */
+    public function get_categories()
+    {
+        return ['givewp-category'];
+    }
 
-	/**
-	 * Get widget categories.
-	 *
-	 * Retrieve the list of categories the Give Form widget belongs to.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return array Widget categories.
-	 */
-	public function get_categories() {
-		return [ 'givewp-category' ];
-	}
+    /**
+     * Register Give Form widget controls.
+     *
+     * Adds different input fields to allow the user to change and customize the widget settings.
+     *
+     * @since  1.0.0
+     * @access protected
+     */
+    protected function register_controls()
+    {
+        $this->start_controls_section(
+            'give_form_settings',
+            [
+                'label' => __('GiveWP Form Widget', 'dw4elementor'),
+                'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+            ]
+        );
 
-	/**
-	 * Register Give Form widget controls.
-	 *
-	 * Adds different input fields to allow the user to change and customize the widget settings.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 */
-	protected function register_controls() {
+        $this->add_control(
+            'form_id',
+            [
+                'label'       => __('Form ID', 'dw4elementor'),
+                'type'        => \Elementor\Controls_Manager::SELECT,
+                'description' => __('Choose the GiveWP Form you want to embed.', 'dw4elementor'),
+                'default'     => '',
+                'options'     => $this->get_donation_forms_options(),
+            ]
+        );
 
-		$this->start_controls_section(
-			'give_form_settings',
-			[
-				'label' => __( 'GiveWP Form Widget', 'dw4elementor' ),
-				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
-			]
-		);
+        $this->add_control(
+            'show_title',
+            [
+                'label'       => __('Show Form Title', 'dw4elementor'),
+                'type'        => \Elementor\Controls_Manager::SWITCHER,
+                'description' => __('Show/hide the GiveWP form title.', 'dw4elementor'),
+                'label_on'    => __('Show', 'dw4elementor'),
+                'label_off'   => __('Hide', 'dw4elementor'),
+                'default'     => 'yes',
+            ]
+        );
 
-		$this->add_control(
-			'form_id',
-			[
-				'label' => __( 'Form ID', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::TEXT,
-				'description' => __( 'Choose the GiveWP Form ID you want to embed.', 'dw4elementor' ),
-				'input_type' => 'number',
-			]
-		);
-
-		$this->add_control(
-			'show_title',
-			[
-				'label' => __( 'Show Form Title', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::SWITCHER,
-				'description' => __( 'Show/hide the GiveWP form title.', 'dw4elementor' ),
-				'label_on' => __( 'Show', 'dw4elementor' ),
-				'label_off' => __( 'Hide', 'dw4elementor' ),
-				'default' => 'yes',
-			]
-		);
-
-		$this->add_control(
-			'show_goal',
-			[
-				'label' => __( 'Show Goal', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::SWITCHER,
-				'description' => __( 'Show/hide the progress bar and goal for this form.', 'dw4elementor' ),
-				'label_on' => __( 'Show', 'dw4elementor' ),
-				'label_off' => __( 'Hide', 'dw4elementor' ),
-				'return_value' => 'yes',
-				'default' => 'yes',
-			]
-		);
+        $this->add_control(
+            'show_goal',
+            [
+                'label'        => __('Show Goal', 'dw4elementor'),
+                'type'         => \Elementor\Controls_Manager::SWITCHER,
+                'description'  => __('Show/hide the progress bar and goal for this form.', 'dw4elementor'),
+                'label_on'     => __('Show', 'dw4elementor'),
+                'label_off'    => __('Hide', 'dw4elementor'),
+                'return_value' => 'yes',
+                'default'      => 'yes',
+            ]
+        );
 
 
-		$this->add_control(
-			'show_content',
-			[
-				'label' => __( 'Show Form Content', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::SWITCHER,
-				'description' => __( 'Show/hide the content of this form.', 'dw4elementor' ),
-				'label_on' => __( 'Show', 'dw4elementor' ),
-				'label_off' => __( 'Hide', 'dw4elementor' ),
-				'return_value' => 'yes',
-				'default' => 'no',
-			]
-		);
+        $this->add_control(
+            'show_content',
+            [
+                'label'        => __('Show Form Content', 'dw4elementor'),
+                'type'         => \Elementor\Controls_Manager::SWITCHER,
+                'description'  => __('Show/hide the content of this form.', 'dw4elementor'),
+                'label_on'     => __('Show', 'dw4elementor'),
+                'label_off'    => __('Hide', 'dw4elementor'),
+                'return_value' => 'yes',
+                'default'      => 'no',
+            ]
+        );
 
-		$this->add_control(
-			'display_style',
-			[
-				'label' => __( 'Form Display Style', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::SELECT,
-				'description' => __( 'Choose which display to use for this GiveWP form.', 'dw4elementor' ),
-				'options' => [
-					'onpage' => __('Full Form','dw4elementor'),
-					'button' => __('Button Only', 'dw4elementor'),
-					'modal' => __('Modal Reveal', 'dw4elementor'),
-					'reveal' => __('Reveal', 'dw4elementor')
-				],
-				'default' => 'onpage'
-			]
-		);
+        $this->add_control(
+            'display_style',
+            [
+                'label'       => __('Form Display Style', 'dw4elementor'),
+                'type'        => \Elementor\Controls_Manager::SELECT,
+                'description' => __('Choose which display to use for this GiveWP form.', 'dw4elementor'),
+                'options'     => [
+                    'onpage' => __('Full Form', 'dw4elementor'),
+                    'button' => __('Button Only', 'dw4elementor'),
+                    'modal'  => __('Modal Reveal', 'dw4elementor'),
+                    'reveal' => __('Reveal', 'dw4elementor'),
+                ],
+                'default'     => 'onpage',
+            ]
+        );
 
-		$this->add_control(
-			'continue_button_title',
-			[
-				'label' => __( 'Reveal Button Text', 'dw4elementor' ),
-				'type' => \Elementor\Controls_Manager::TEXT,
-				'description' => __( 'Text on the button that reveals the form.', 'dw4elementor' ),
-				'default' => __('Continue to Donate', 'dw4elementor'),
-				'condition' => [
-					'display_style!' => 'onpage',
-				]
-			]
-		);
+        $this->add_control(
+            'continue_button_title',
+            [
+                'label'       => __('Reveal Button Text', 'dw4elementor'),
+                'type'        => \Elementor\Controls_Manager::TEXT,
+                'description' => __('Text on the button that reveals the form.', 'dw4elementor'),
+                'default'     => __('Continue to Donate', 'dw4elementor'),
+                'condition'   => [
+                    'display_style!' => 'onpage',
+                ],
+            ]
+        );
 
-		$this->add_control(
-			'give_form_info',
-			[
-				'label' => '',
-				'type' => \Elementor\Controls_Manager::RAW_HTML,
-				'content_classes' => 'dw4e-info',
-				'raw' => '
+        $this->add_control(
+            'give_form_info',
+            [
+                'label'           => '',
+                'type'            => \Elementor\Controls_Manager::RAW_HTML,
+                'content_classes' => 'dw4e-info',
+                'raw'             => '
 					<div class="dw4e">
 						<p class="info-head">
 							' . __('GIVEWP FORM WIDGET', 'dw4elementor') . '</p>
-						<p class="info-message">' . __('This is the GiveWP Form widget. Choose which form you want to embed on this page with it\'s form "ID".', 'dw4elementor') . '</p>
+						<p class="info-message">' . __(
+                        'This is the GiveWP Form widget. Choose which form you want to embed on this page with it\'s form "ID".',
+                        'dw4elementor'
+                    ) . '</p>
 						<p class="dw4e-docs-links">
-							<a href="https://givewp.com/documentation/core/shortcodes/give_form/?utm_source=plugin_settings&utm_medium=referral&utm_campaign=Free_Addons&utm_content=dw4elementor" rel="noopener noreferrer" target="_blank"><i class="fa fa-book" aria-hidden="true"></i>' . __('Visit the GiveWP Docs for more info on the GiveWP Form.', 'dw4elementor') . '</a>
+							<a href="https://givewp.com/documentation/core/shortcodes/give_form/?utm_source=plugin_settings&utm_medium=referral&utm_campaign=Free_Addons&utm_content=dw4elementor" rel="noopener noreferrer" target="_blank"><i class="fa fa-book" aria-hidden="true"></i>' . __(
+                                         'Visit the GiveWP Docs for more info on the GiveWP Form.',
+                                         'dw4elementor'
+                                     ) . '</a>
 						</p>
-				</div>'
-			]
-		);
+				</div>',
+            ]
+        );
 
-		$this->end_controls_section();
+        $this->end_controls_section();
+    }
 
-	}
+    /**
+     * Render the [give_form] output on the frontend.
+     *
+     * Written in PHP and used to generate the final HTML.
+     *
+     * @since  1.0.0
+     * @access protected
+     */
+    protected function render()
+    {
+        $settings = $this->get_data('settings');
 
-	/**
-	 * Render the [give_form] output on the frontend.
-	 *
-	 * Written in PHP and used to generate the final HTML.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 */
-	protected function render() {
+        $form_id               = $this->get_settings('form_id');
+        $show_title            = isset($settings['show_title']) ? $settings['show_title'] : 'true';
+        $show_goal             = isset($settings['show_goal']) ? $settings['show_goal'] : 'true';
+        $show_content          = isset($settings['show_content']) ? $settings['show_content'] : 'true';
+        $display_style         = isset($settings['display_style']) ? $settings['display_style'] : 'onpage';
+        $continue_button_title = isset($settings['continue_button_title']) ? $settings['continue_button_title'] : __('Continue to Donate', 'dw4elementor');
 
-		global $give_receipt_args, $donation;
+        if (isset($_POST['action']) && $_POST['action'] === 'elementor_ajax') {
+            // is this v3 form?
+            if (get_post_meta($form_id, 'formBuilderSettings', true)) {
+                if ($donationForm = DonationForm::find($form_id)) {
+                    $donationForm->settings->showHeading        = boolval($show_title);
+                    $donationForm->settings->enableDonationGoal = boolval($show_goal);
+                    $donationForm->save();
+                }
+            }
+        }
 
-		$settings = $this->get_settings_for_display();
+        $shortcode = sprintf(
+            '[give_form id="%s" show_title="%s" show_goal="%s" show_content="%s" display_style="%s" continue_button_title="%s"]',
+            $form_id,
+            $show_title,
+            $show_goal,
+            $show_content,
+            $display_style,
+            $continue_button_title
+        );
 
-		$form_id = ( 'yes' === $settings['form_id'] ? '' : esc_attr($settings['form_id']));
-		$show_title = ( 'yes' === $settings['show_title'] ? 'true' :  'false');
-		$show_goal = ( 'yes' === $settings['show_goal'] ? 'true' :  'false');
-		$show_content = ( 'yes' === $settings['show_content'] ? 'true' :  'false');
-		$display_style = esc_attr( $settings['display_style'] );
-		$continue_button_title = esc_attr( $settings['continue_button_title'] );
+        echo '<div class="givewp-elementor-widget give-form-shortcode-wrap">';
 
-		$html = do_shortcode('
-			[give_form 
-				id="' . $form_id . '" 
-				show_title="' . $show_title . '" 
-				show_goal="' . $show_goal . '" 
-				show_content="' . $show_content . '" 
-				display_style="' . $display_style . '" 
-				continue_button_title="' . $continue_button_title . '" 
-				]'
-		);
+        echo do_shortcode($shortcode);
 
-		echo '<div class="givewp-elementor-widget give-form-shortcode-wrap">';
+        echo '</div>';
+    }
 
-		echo $html;
+    /**
+     * @return array
+     */
+    private function get_donation_forms_options()
+    {
+        $options = [];
 
-		echo '</div>';
-	}
+        $forms = DB::table('posts')
+                   ->select('ID', 'post_title')
+                   ->where('post_type', 'give_forms')
+                   ->where('post_status', 'publish')
+                   ->getAll();
 
-	private function get_donation_forms() {
+        foreach ($forms as $form) {
+            $options[$form->ID] = $form->post_title;
+        }
 
-		// Define variables.
-		$result         = array();
-		$post_data      = give_clean( $_POST );
-		$search_keyword = ! empty( $post_data['search'] ) ? $post_data['search'] : '';
-
-		// Setup the arguments to fetch the donation forms.
-		$forms_query = new Give_Forms_Query(
-			array(
-				's'           => $search_keyword,
-				'number'      => 30,
-				'post_status' => 'publish',
-			)
-		);
-
-		// Fetch the donation forms.
-		$forms = $forms_query->get_forms();
-
-		// Loop through each donation form.
-		foreach ( $forms as $form ) {
-			$result[] = array(
-				'id'   => $form->ID,
-				'name' => $form->post_title,
-			);
-		}
-
-		echo wp_json_encode( $result );
-		give_die();
-	}
+        return $options;
+    }
 }

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -90,6 +90,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     {
         $forms       = $this->get_donation_forms_options();
         $legacyForms = $this->get_legacy_forms($forms);
+        $v3Forms     = $this->get_v3_forms($forms);
 
         $this->start_controls_section(
             'give_form_settings',
@@ -183,6 +184,28 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                 'default'     => __('Continue to Donate', 'dw4elementor'),
                 'condition'   => [
                     'display_style!' => 'onpage',
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'v3_notice',
+            [
+                'label'           => __('Important Note', 'dw4elementor'),
+                'type'            => \Elementor\Controls_Manager::RAW_HTML,
+                'raw'             => esc_html__(
+                    'Form Display Style changes will not be visible for Donation forms created using the Visual Form Builder. Save the page and view it on the front end.',
+                    'dw4elementor'
+                ),
+                'content_classes' => 'give-elementor-notice',
+                'conditions'      => [
+                    'terms' => [
+                        [
+                            'name'     => 'form_id',
+                            'operator' => 'in',
+                            'value'    => $v3Forms,
+                        ],
+                    ],
                 ],
             ]
         );
@@ -292,6 +315,24 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
 
         foreach ($forms as $formId => $title) {
             if ('legacy' === Give()->form_meta->get_meta($formId, '_give_form_template', true)) {
+                $data[] = (string)$formId;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array $forms
+     *
+     * @return array
+     */
+    private function get_v3_forms($forms)
+    {
+        $data = [];
+
+        foreach ($forms as $formId => $title) {
+            if (Give()->form_meta->get_meta($formId, 'formBuilderSettings', true)) {
                 $data[] = (string)$formId;
             }
         }

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -88,9 +88,10 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
      */
     protected function register_controls()
     {
-        $forms       = $this->get_donation_forms_options();
-        $legacyForms = $this->get_legacy_forms($forms);
-        $v3Forms     = $this->get_v3_forms($forms);
+        $forms        = $this->get_donation_forms_options();
+        $legacyForms  = $this->get_legacy_forms($forms);
+        $classicForms = $this->get_classic_forms($forms);
+        $v3Forms      = $this->get_v3_forms($forms);
 
         $this->start_controls_section(
             'give_form_settings',
@@ -120,6 +121,15 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                 'label_on'    => __('Show', 'dw4elementor'),
                 'label_off'   => __('Hide', 'dw4elementor'),
                 'default'     => 'yes',
+                'conditions'  => [
+                    'terms' => [
+                        [
+                            'name'     => 'form_id',
+                            'operator' => '!in',
+                            'value'    => $classicForms,
+                        ],
+                    ],
+                ],
             ]
         );
 
@@ -305,7 +315,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     }
 
     /**
-     * Get legacy forms from list of forms returned by DW4Elementor_GiveWP_Form_Widget::get_donation_forms_options
+     * Get forms using legacy template from list of forms returned by DW4Elementor_GiveWP_Form_Widget::get_donation_forms_options
      *
      * @unlreased
      *
@@ -318,7 +328,29 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
         $data = [];
 
         foreach (array_keys($forms) as $formId) {
-            if ('legacy' === Give()->form_meta->get_meta($formId, '_give_form_template', true)) {
+            if ('legacy' === $this->get_form_template($formId)) {
+                $data[] = (string)$formId;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get forms using classic template from list of forms returned by DW4Elementor_GiveWP_Form_Widget::get_donation_forms_options
+     *
+     * @unlreased
+     *
+     * @param array $forms
+     *
+     * @return array
+     */
+    private function get_classic_forms($forms)
+    {
+        $data = [];
+
+        foreach (array_keys($forms) as $formId) {
+            if ('classic' === $this->get_form_template($formId)) {
                 $data[] = (string)$formId;
             }
         }
@@ -340,11 +372,25 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
         $data = [];
 
         foreach (array_keys($forms) as $formId) {
-            if (Give()->form_meta->get_meta($formId, 'formBuilderSettings', true)) {
+            if (get_post_meta($formId, 'formBuilderSettings', true)) {
                 $data[] = (string)$formId;
             }
         }
 
         return $data;
+    }
+
+    /**
+     * Get form template
+     *
+     * @unreleased
+     *
+     * @param $formId
+     *
+     * @return string
+     */
+    private function get_form_template($formId)
+    {
+        return Give()->form_meta->get_meta($formId, '_give_form_template', true);
     }
 }

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -88,6 +88,9 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
      */
     protected function register_controls()
     {
+        $forms       = $this->get_donation_forms_options();
+        $legacyForms = $this->get_legacy_forms($forms);
+
         $this->start_controls_section(
             'give_form_settings',
             [
@@ -103,7 +106,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                 'type'        => \Elementor\Controls_Manager::SELECT,
                 'description' => __('Choose the GiveWP Form you want to embed.', 'dw4elementor'),
                 'default'     => '',
-                'options'     => $this->get_donation_forms_options(),
+                'options'     => $forms,
             ]
         );
 
@@ -143,6 +146,15 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                 'label_off'    => __('Hide', 'dw4elementor'),
                 'return_value' => 'yes',
                 'default'      => 'no',
+                'conditions'   => [
+                    'terms' => [
+                        [
+                            'name'     => 'form_id',
+                            'operator' => 'in',
+                            'value'    => $legacyForms,
+                        ],
+                    ],
+                ],
             ]
         );
 
@@ -267,5 +279,23 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
         }
 
         return $options;
+    }
+
+    /**
+     * @param array $forms
+     *
+     * @return array
+     */
+    private function get_legacy_forms($forms)
+    {
+        $data = [];
+
+        foreach ($forms as $formId => $title) {
+            if ('legacy' === Give()->form_meta->get_meta($formId, '_give_form_template', true)) {
+                $data[] = (string)$formId;
+            }
+        }
+
+        return $data;
     }
 }

--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -217,7 +217,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 					'date' => __('Date Created', 'dw4elementor'),
 					'title' => __('Form Name', 'dw4elementor'),
 					'amount_donated' => __('Amount Donated', 'dw4elementor'),
-					'name' => __('Form Name', 'dw4elementor'),
 					'number_donations' => __('Number of Donations', 'dw4elementor'),
 					'menu_order' => __('Menu Order', 'dw4elementor'),
 					'post__in' => __('Form ID', 'dw4elementor'),

--- a/widgets/give_totals.php
+++ b/widgets/give_totals.php
@@ -211,15 +211,8 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 	 */
 	protected function render() {
 
-		global $give_receipt_args, $donation;
+        $settings = $this->get_settings_for_display();
 
-        if ( empty($settings['forms']) ) {
-            return;
-        }
-
-		$settings = $this->get_settings_for_display();
-
-		$forms = $settings['forms'][0];
 		$goal = esc_html( $settings['total_goal'] );
 		$message = esc_html( $settings['message'] );
 		$link = esc_url( $settings['link']['url'] );
@@ -229,7 +222,7 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 
 		$html = do_shortcode('
 			[give_totals 
-				ids="' . $forms . '" 
+				ids="' . implode(',', $settings['forms']) . '" 
 				total_goal="' . $goal . '" 
 				message="' . $message . '"
 				link_text="' . $link_text . '"

--- a/widgets/give_totals.php
+++ b/widgets/give_totals.php
@@ -1,4 +1,7 @@
 <?php
+
+use Give\Framework\Database\DB;
+
 /**
  * Elementor Give Totals Widget.
  *
@@ -94,11 +97,9 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 				'type' => \Elementor\Controls_Manager::SELECT2,
 				'description' => __( 'Choose the forms you want to combine in this total.', 'dw4elementor' ),
 				'separator' => 'after',
-				'options' => [
-					'10' => "First Form"
-				],
+				'options' => $this->get_donation_forms(),
 				'multiple' => true,
-				'default' => array('10'),
+				'default' => '',
 			]
 		);
 
@@ -212,6 +213,10 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 
 		global $give_receipt_args, $donation;
 
+        if ( empty($settings['forms']) ) {
+            return;
+        }
+
 		$settings = $this->get_settings_for_display();
 
 		$forms = $settings['forms'][0];
@@ -240,4 +245,28 @@ class DW4Elementor_GiveWP_Totals_Widget extends \Elementor\Widget_Base {
 
 		echo '</div>';
 	}
+
+    /**
+     * Get donation forms
+     *
+     * @unreleased
+     *
+     * @return array
+     */
+    private function get_donation_forms()
+    {
+        $options = [];
+
+        $forms = DB::table('posts')
+                   ->select('ID', 'post_title')
+                   ->where('post_type', 'give_forms')
+                   ->where('post_status', 'publish')
+                   ->getAll();
+
+        foreach ($forms as $form) {
+            $options[$form->ID] = $form->post_title;
+        }
+
+        return $options;
+    }
 }


### PR DESCRIPTION
## Description

This PR adds compatibility for the new V3 forms. There are some limitations due to how the v3 form are displayed and the Display Style option is not working as other options (this option is saved, but the preview doesn't work in Elementor builder). A note is added when a user selects the v3 form saying that preview is not possible inside the Elementor.

## Affects

Give Form widget

## Testing Instructions
Install Give
Install Elementor
Install Give Elementor add-on
Create v2 and v3 forms
Create a page using Elementor
Insert the Donation Form widget and select the form to display
## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

