### PR TITLE
Feature: show hide goal for v2 forms

### DIFF
--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -276,6 +276,14 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                     $donationForm->save();
                 }
             }
+
+            // show hide goal for legacy template
+            if ($show_goal && Utils::isLegacyForm($form_id)) {
+                // Enable goal if it's disabled
+                if ('disabled' === give_get_meta($form_id, '_give_goal_option', true)) {
+                    give_update_meta($form_id, '_give_goal_option', 'enabled');
+                }
+            }
         }
 
         $shortcode = sprintf(

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -260,7 +260,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
     {
         $settings = $this->get_data('settings');
 
-        $form_id               = $this->get_settings('form_id');
+        $form_id               = (int)$this->get_settings('form_id');
         $show_title            = isset($settings['show_title']) ? $settings['show_title'] : 'true';
         $show_goal             = isset($settings['show_goal']) ? $settings['show_goal'] : 'true';
         $show_content          = isset($settings['show_content']) ? $settings['show_content'] : 'true';
@@ -275,14 +275,9 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
                     $donationForm->settings->enableDonationGoal = boolval($show_goal);
                     $donationForm->save();
                 }
-            }
-
-            // show hide goal for legacy template
-            if ($show_goal && Utils::isLegacyForm($form_id)) {
-                // Enable goal if it's disabled
-                if ('disabled' === give_get_meta($form_id, '_give_goal_option', true)) {
-                    give_update_meta($form_id, '_give_goal_option', 'enabled');
-                }
+            } else {
+                // For some strange reason, passing show_goal attr to give_form shortcode doesn't work, so in order for this to work we have to enable/disable goal by updating meta
+                give_update_meta($form_id, '_give_goal_option', $show_goal ? 'enabled' : 'disabled');
             }
         }
 

--- a/widgets/give_form.php
+++ b/widgets/give_form.php
@@ -381,7 +381,7 @@ class DW4Elementor_GiveWP_Form_Widget extends \Elementor\Widget_Base
         $data = [];
 
         foreach (array_keys($forms) as $formId) {
-            if (Utils::isV3Form($formId)) {
+            if (Utils::isV3Form((int)$formId)) {
                 $data[] = (string)$formId;
             }
         }


### PR DESCRIPTION
Resolves: [GIVE-164]

## Description
This PR resolves the issue where form goal wasn't showing for v2 forms. Show/hide goal was not working if goal option was disabled for the form. The issue is resolved by enabling goal option automatically if user turns on that option form the Elementor editor. 


## Testing Instructions

Create v2 form with goal option disabled. 
Inside elementor editor add Give Form widget and select v2 form
Turn on/off goal option


<!-- Help others test your PR as efficiently as possible. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-164]: https://stellarwp.atlassian.net/browse/GIVE-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ