### PR TITLE
Refactor: remove "show progress bar" option

### DIFF
--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -74,6 +74,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 *
 	 * Adds different input fields to allow the user to change and customize the widget settings.
 	 *
+     * @unreleased Remove "show progress bar" option
 	 * @since 1.0.0
 	 * @access protected
 	 */
@@ -305,21 +306,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 			]
 		);
 
-        $this->add_control(
-            'show_bar',
-            [
-                'label' => __( 'Show Progress Bar', 'dw4elementor' ),
-                'type' => \Elementor\Controls_Manager::SWITCHER,
-                'description' => __( 'Show Progress Bar.', 'dw4elementor' ),
-                'label_on' => __( 'Show', 'dw4elementor' ),
-                'label_off' => __( 'Hide', 'dw4elementor' ),
-                'default' => 'yes',
-                'condition' => [
-                    'show_goal' => 'yes'
-                ]
-            ]
-        );
-
 		$this->add_control(
 			'show_featured_image',
 			[
@@ -433,6 +419,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 *
 	 * Written in PHP and used to generate the final HTML.
 	 *
+     * @unreleased Remove "show progress bar" option
 	 * @since 1.0.0
 	 * @access protected
 	 */
@@ -453,7 +440,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 		$tags = esc_html( $settings['tags'] );
 		$show_title = esc_html( $settings['show_title'] );
 		$show_goal = esc_html( $settings['show_goal'] );
-        $show_bar = esc_html( $settings['show_bar'] );
 		$show_excerpt = esc_html( $settings['show_excerpt'] );
         $excerpt_length = esc_html( $settings['excerpt_length'] );
 		$show_featured_image = esc_html( $settings['show_featured_image'] );
@@ -475,8 +461,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 				cats="' . $cats . '" 
 				tags="' . $tags . '" 
 				show_title="' . $show_title . '" 
-				show_goal="' . $show_goal . '" 
-				show_bar="' . $show_bar . '" 
+				show_goal="' . $show_goal . '" 				
 				show_excerpt="' . $show_excerpt . '" 
 				excerpt_length="' . $excerpt_length . '" 
 				show_featured_image="' . $show_featured_image . '" 


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-166]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The "Show Progress Bar" option in the Form Grid widget only exists in the Elementor, but it doesn't exist in the shortcode or block. So, we had two options... 

1. Remove it from Elementor; 
2. Implement it in the shortcode/block. 

The first one was chosen and this PR implements it.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Form Grid widget

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/e3815bc8e85c4c94a5511cfe317be522?sid=2615076e-aa44-4507-a892-0ce20ba09e68

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add the Form Grid widget to an Elementor page;
2. The "Show Progress Bar" option should not be available anymore.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-166]: https://stellarwp.atlassian.net/browse/GIVE-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ