### PR TITLE
Fix: hidden text donation button and non-functional options in the Form Grid widget

### DIFF
--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -73,7 +73,8 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 * Register Give Form Grid widget controls.
 	 *
 	 * Adds different input fields to allow the user to change and customize the widget settings.
-	 *
+     *
+     * @unreleased Changes 'donate_button_text_color' default value and removes 'show_bar' and 'donate_button_background_color' options as those don't exist in the form grid shortcode.
 	 * @since 1.0.0
 	 * @access protected
 	 */
@@ -305,21 +306,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 			]
 		);
 
-        $this->add_control(
-            'show_bar',
-            [
-                'label' => __( 'Show Progress Bar', 'dw4elementor' ),
-                'type' => \Elementor\Controls_Manager::SWITCHER,
-                'description' => __( 'Show Progress Bar.', 'dw4elementor' ),
-                'label_on' => __( 'Show', 'dw4elementor' ),
-                'label_off' => __( 'Hide', 'dw4elementor' ),
-                'default' => 'yes',
-                'condition' => [
-                    'show_goal' => 'yes'
-                ]
-            ]
-        );
-
 		$this->add_control(
 			'show_featured_image',
 			[
@@ -366,18 +352,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
                 'default' => 'yes',
             ]
         );
-
-        /*$this->add_control(
-            'donate_button_background_color',
-            [
-                'label' => __( 'Donate Button Background Color', 'dw4elementor' ),
-                'type' => \Elementor\Controls_Manager::COLOR,
-                'default' => '#66bb6a',
-                'condition' => [
-                    'show_donate_button' => 'yes'
-                ]
-            ]
-        );*/
 
         $this->add_control(
             'donate_button_text_color',
@@ -431,7 +405,8 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 	 * Render the [give_form_grid] output on the frontend.
 	 *
 	 * Written in PHP and used to generate the final HTML.
-	 *
+     *
+     * @unreleased Changes 'donate_button_text_color' default value and removes 'show_bar' and 'donate_button_background_color' options as those don't exist in the form grid shortcode.
 	 * @since 1.0.0
 	 * @access protected
 	 */
@@ -452,7 +427,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 		$tags = esc_html( $settings['tags'] );
 		$show_title = esc_html( $settings['show_title'] );
 		$show_goal = esc_html( $settings['show_goal'] );
-        $show_bar = esc_html( $settings['show_bar'] );
 		$show_excerpt = esc_html( $settings['show_excerpt'] );
         $excerpt_length = esc_html( $settings['excerpt_length'] );
 		$show_featured_image = esc_html( $settings['show_featured_image'] );
@@ -460,7 +434,6 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 		$image_size = esc_html( $settings['image_size'] );
 		$image_height = esc_html( $settings['image_height'] );
         $show_donate_button = esc_html($settings['show_donate_button']);
-		$button_bg_color = esc_html( $settings['donate_button_background_color'] );
 		$button_text_color = esc_html( $settings['donate_button_text_color'] );
 
 		$html = do_shortcode('
@@ -474,8 +447,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 				cats="' . $cats . '" 
 				tags="' . $tags . '" 
 				show_title="' . $show_title . '" 
-				show_goal="' . $show_goal . '" 
-				show_bar="' . $show_bar . '" 
+				show_goal="' . $show_goal . '" 				 
 				show_excerpt="' . $show_excerpt . '" 
 				excerpt_length="' . $excerpt_length . '" 
 				show_featured_image="' . $show_featured_image . '" 

--- a/widgets/give_form_grid.php
+++ b/widgets/give_form_grid.php
@@ -363,11 +363,11 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
                 'type' => \Elementor\Controls_Manager::SWITCHER,
                 'label_on' => __( 'Show', 'dw4elementor' ),
                 'label_off' => __( 'Hide', 'dw4elementor' ),
-                'default' => 'no',
+                'default' => 'yes',
             ]
         );
 
-        $this->add_control(
+        /*$this->add_control(
             'donate_button_background_color',
             [
                 'label' => __( 'Donate Button Background Color', 'dw4elementor' ),
@@ -377,18 +377,17 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
                     'show_donate_button' => 'yes'
                 ]
             ]
-        );
+        );*/
 
         $this->add_control(
             'donate_button_text_color',
             [
                 'label' => __( 'Donate Button Text Color', 'dw4elementor' ),
                 'type' => \Elementor\Controls_Manager::COLOR,
-                'default' => '#fff',
+                'default' => '#69B86B',
                 'condition' => [
                     'show_donate_button' => 'yes'
                 ],
-
             ]
         );
 
@@ -482,8 +481,7 @@ class DW4Elementor_GiveWP_Form_Grid_Widget extends \Elementor\Widget_Base {
 				show_featured_image="' . $show_featured_image . '" 
 				image_size="' . $image_size . '" 
 				image_height="' . $image_height . '" 
-				show_donate_button="' . $show_donate_button . '" 
-				donate_button_background_color="' . $button_bg_color . '" 
+				show_donate_button="' . $show_donate_button . '" 				 
 				donate_button_text_color="' . $button_text_color . '" 
 				display_style="' . $display_style . '" 
 				orderby="' . $orderby .


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-166] and [GIVE-168]

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

The _"Show Progress Bar"_ and the _"Show Donation Button > Button Background Color"_ options in the Form Grid widget only existed in the Elementor, but it doesn't exist in the shortcode or block as you can check in the codebase or the docs: https://givewp.com/documentation/core/shortcodes/give_form_grid/

So, the solution implemented in this PR was to remove these options from the Elementor Form Grid widget as they never existed in fact.

This PR also changed the _"Donate Button Text Color"_ to "green" (like in the Form Grid Block) because before it was using "white" as the default color and was confusing the users cause it was making the text "hidden" on white pages. Also, the _"Show Donation Button"_ option is enabled by default - the same behavior as the Form Grid Block.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

The Form Grid Widget

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

https://www.loom.com/share/e3815bc8e85c4c94a5511cfe317be522?sid=2615076e-aa44-4507-a892-0ce20ba09e68

👆 In the video above I demonstrate the _"Show Progress Bar"_ option only exists in the Elementor settings, but the same approach can be used to check that the _"Button Background Color"_ option only exists in the Elementor settings as well.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

1. Add the Form Grid widget to an Elementor page;
2. The _"Show Progress Bar"_ and _"Show Donation Button > Button Background Color"_ options should not be available anymore;
3. The _"Show Donation Button"_ option should be enabled and the "Donate Button Text Color" should be green instead of white.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-166]: https://stellarwp.atlassian.net/browse/GIVE-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GIVE-168]: https://stellarwp.atlassian.net/browse/GIVE-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ